### PR TITLE
feat(api): bulk per-document update/upsert via POST /api/v2/crud/bulk/

### DIFF
--- a/UI/datacube-UI/src/data/apiReference.ts
+++ b/UI/datacube-UI/src/data/apiReference.ts
@@ -282,7 +282,7 @@ export const apiDocs: ApiGroup[] = [
         name: "CRUD — update",
         auth_required: "JWT or API key — developer/admin",
         description:
-          "Single-doc updates require `_id` in filters unless `update_many` is true. See `update_all_fields`, `upsert` in full docs.",
+          "Single-doc updates require `_id` in filters unless `update_many` is true. `upsert` cannot be combined with `update_many` — use bulk update for mixed per-document sync.",
         url: "/api/v2/crud/",
         methods: [
           {
@@ -300,6 +300,46 @@ export const apiDocs: ApiGroup[] = [
               success: true,
               modified_count: 1,
               matched_count: 1,
+            }),
+          },
+        ],
+      },
+      {
+        name: "CRUD — bulk update / upsert",
+        auth_required: "JWT or API key — developer/admin",
+        description:
+          "Sync many documents in one request. Each operation is an independent updateOne with optional upsert (requires `_id` and `update_all_fields: true`). Max 500 operations.",
+        url: "/api/v2/crud/bulk/",
+        methods: [
+          {
+            method: "POST",
+            body: j({
+              database_id: DB_ID,
+              collection_name: "users",
+              operations: [
+                {
+                  filters: { _id: DOC_ID },
+                  update_data: { points: 120 },
+                  update_all_fields: true,
+                  upsert: true,
+                },
+                {
+                  filters: { _id: "674a1b2c3d4e5f6789012346" },
+                  update_data: { points: 450 },
+                  update_all_fields: true,
+                  upsert: true,
+                },
+              ],
+            }),
+            response: j({
+              success: true,
+              matched_count: 1,
+              modified_count: 1,
+              upserted_count: 1,
+              results: [
+                { index: 0, ok: true },
+                { index: 1, ok: true, upserted_id: "674a1b2c3d4e5f6789012347" },
+              ],
             }),
           },
         ],

--- a/backend/README.md
+++ b/backend/README.md
@@ -34,6 +34,7 @@ Endpoints include (all typically authenticated except `health_check`):
 - `DELETE …/drop_database/`, `drop_collections/`
 - `POST …/import_data/`
 - `POST/GET/PUT/DELETE …/crud/`
+- `POST …/crud/bulk/` — per-document update/upsert batch (`bulkWrite`, max 500 ops)
 - `…/files/` — list/upload; `files/<id>/`, `files/stream/<id>/`, `files/download/<id>/`
 - `GET …/health_check/`
 - `POST …/admin/prune_fields/` — admin permission; prunes inactive field metadata (`database_id`, optional `dry_run`)
@@ -63,6 +64,12 @@ curl -X PUT "https://<HOST>/api/v2/crud/" \
   -H "Authorization: Bearer <ACCESS_TOKEN>" \
   -H "Content-Type: application/json" \
   -d '{"database_id":"<DB_ID>","collection_name":"users","filters":{"_id":"<DOC_ID>"},"update_data":{"status":"active"},"update_all_fields":true}'
+
+# CRUD bulk update / upsert (max 500 operations)
+curl -X POST "https://<HOST>/api/v2/crud/bulk/" \
+  -H "Authorization: Bearer <ACCESS_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{"database_id":"<DB_ID>","collection_name":"users","operations":[{"filters":{"_id":"<DOC_ID>"},"update_data":{"points":120},"update_all_fields":true,"upsert":true}]}'
 ```
 
 ## Dependencies (uv)

--- a/backend/api/application/collection_service.py
+++ b/backend/api/application/collection_service.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional
 
 from django.conf import settings
 from bson import ObjectId, errors
+from pymongo import UpdateOne
 from pymongo.errors import CollectionInvalid, PyMongoError
 
 from api.application.metadata_service import MetadataService
@@ -227,5 +228,20 @@ class CollectionService:
         return await self.db[coll_name].update_many(
             safe_filt,
             {"$set": payload},
+            session=session,
+        )
+
+    async def bulk_write_updates(
+        self,
+        coll_name: str,
+        requests: List[UpdateOne],
+        session=None,
+    ):
+        """Execute independent updateOne operations in one bulkWrite call."""
+        if not requests:
+            return None
+        return await self.db[coll_name].bulk_write(
+            requests,
+            ordered=False,
             session=session,
         )

--- a/backend/api/application/document_service.py
+++ b/backend/api/application/document_service.py
@@ -17,7 +17,9 @@ from api.infrastructure.query_safety import (
     prepare_update_document,
     validate_filter,
 )
-from pymongo.errors import PyMongoError
+from api.infrastructure.mongodb import build_existing_fields_update_pipeline
+from pymongo import UpdateOne
+from pymongo.errors import BulkWriteError, PyMongoError
 
 
 class DocumentService:
@@ -96,6 +98,146 @@ class DocumentService:
         except PyMongoError as e:
             raise RuntimeError(f"Failed to create documents: {e}")
 
+    def _prepare_update_payload(
+        self,
+        update_data: dict,
+        *,
+        allow_new_fields: bool,
+        upsert: bool,
+    ) -> Tuple[dict | list, Dict]:
+        """Build a MongoDB update document/pipeline and schema inference sample."""
+        if upsert and not allow_new_fields:
+            raise ValueError("upsert requires update_all_fields=true.")
+
+        if allow_new_fields:
+            update_doc, schema_sample = prepare_update_document(update_data)
+            if upsert:
+                set_on_insert = update_doc.setdefault("$setOnInsert", {})
+                if not isinstance(set_on_insert, dict):
+                    raise ValueError("$setOnInsert must be an object when provided.")
+                set_on_insert.setdefault("is_deleted", False)
+            return update_doc, schema_sample
+
+        if is_operator_update(update_data) and not (
+            set(update_data.keys()) == {"$set"}
+        ):
+            raise ValueError(
+                "Operator updates other than a lone $set require update_all_fields=true."
+            )
+        plain = plain_fields_for_partial_update(update_data)
+        return build_existing_fields_update_pipeline(plain), plain
+
+    @staticmethod
+    def _format_bulk_write_response(
+        *,
+        op_count: int,
+        matched_count: int,
+        modified_count: int,
+        upserted_count: int,
+        upserted_by_index: Dict[int, str],
+        write_errors: Optional[List[Dict]] = None,
+    ) -> Dict:
+        error_by_index: Dict[int, str] = {}
+        for err in write_errors or []:
+            idx = err.get("index")
+            if idx is not None:
+                error_by_index[idx] = err.get("errmsg") or str(err)
+
+        results = []
+        for index in range(op_count):
+            entry: Dict = {"index": index, "ok": index not in error_by_index}
+            if index in upserted_by_index:
+                entry["upserted_id"] = upserted_by_index[index]
+            if index in error_by_index:
+                entry["error"] = error_by_index[index]
+            results.append(entry)
+
+        body: Dict = {
+            "matched_count": matched_count,
+            "modified_count": modified_count,
+            "upserted_count": upserted_count,
+            "results": results,
+        }
+        if error_by_index:
+            body["errors"] = [
+                {"index": idx, "message": msg}
+                for idx, msg in sorted(error_by_index.items())
+            ]
+        return body
+
+    async def bulk_update_docs(
+        self,
+        db_id: str,
+        coll_name: str,
+        operations: List[Dict],
+    ) -> Dict:
+        """Apply many independent updateOne operations (optional upsert per row)."""
+        self.ctx.assert_can_write()
+        if not operations:
+            raise ValueError("operations must not be empty.")
+
+        try:
+            svc = await self._get_scoped_collection_svc(db_id, coll_name)
+            requests: List[UpdateOne] = []
+            schema_samples: List[Dict] = []
+
+            for op in operations:
+                filt = op["filters"]
+                validate_filter(filt or {})
+                assert_mutating_filter_allowed(filt or {}, update_many=False)
+
+                allow_new_fields = op.get("update_all_fields", False)
+                upsert = op.get("upsert", False)
+                update_payload, schema_sample = self._prepare_update_payload(
+                    op["update_data"],
+                    allow_new_fields=allow_new_fields,
+                    upsert=upsert,
+                )
+                safe_filt = await svc._prepare_filter(filt)
+                requests.append(
+                    UpdateOne(safe_filt, update_payload, upsert=upsert)
+                )
+                if schema_sample:
+                    schema_samples.append(schema_sample)
+
+            try:
+                result = await svc.bulk_write_updates(coll_name, requests)
+            except BulkWriteError as exc:
+                details = exc.details or {}
+                upserted_by_index = {
+                    item["index"]: str(item["_id"])
+                    for item in details.get("upserted", [])
+                }
+                return self._format_bulk_write_response(
+                    op_count=len(operations),
+                    matched_count=details.get("nMatched", 0),
+                    modified_count=details.get("nModified", 0),
+                    upserted_count=details.get("nUpserted", 0),
+                    upserted_by_index=upserted_by_index,
+                    write_errors=details.get("writeErrors", []),
+                )
+
+            upserted_by_index = {
+                index: str(oid) for index, oid in result.upserted_ids.items()
+            }
+            response = self._format_bulk_write_response(
+                op_count=len(operations),
+                matched_count=result.matched_count,
+                modified_count=result.modified_count,
+                upserted_count=result.upserted_count,
+                upserted_by_index=upserted_by_index,
+            )
+
+            if schema_samples:
+                await self.meta_svc.update_collection_schema_inference(
+                    db_id, coll_name, schema_samples
+                )
+            return response
+        except (ValueError, PermissionError):
+            raise
+        except PyMongoError as e:
+            raise RuntimeError(f"Failed to bulk update documents: {e}") from e
+
     async def update_docs(
         self,
         db_id: str,
@@ -118,38 +260,30 @@ class DocumentService:
             if not (filt.get("_id") or filt.get("id")):
                 raise ValueError("upsert requires '_id' or 'id' in filters.")
 
-        update_doc, schema_sample = prepare_update_document(update_data)
-        if upsert:
-            set_on_insert = update_doc.setdefault("$setOnInsert", {})
-            if not isinstance(set_on_insert, dict):
-                raise ValueError("$setOnInsert must be an object when provided.")
-            set_on_insert.setdefault("is_deleted", False)
+        update_payload, schema_sample = self._prepare_update_payload(
+            update_data,
+            allow_new_fields=allow_new_fields,
+            upsert=upsert,
+        )
 
         try:
             svc = await self._get_scoped_collection_svc(db_id, coll_name)
 
             if allow_new_fields:
                 if update_many:
-                    result = await svc.update_many_raw(coll_name, filt, update_doc)
+                    result = await svc.update_many_raw(coll_name, filt, update_payload)
                 else:
                     result = await svc.update_one_raw(
-                        coll_name, filt, update_doc, upsert=upsert
+                        coll_name, filt, update_payload, upsert=upsert
                     )
             else:
-                if is_operator_update(update_data) and not (
-                    set(update_data.keys()) == {"$set"}
-                ):
-                    raise ValueError(
-                        "Operator updates other than a lone $set require update_all_fields=true."
-                    )
-                plain = plain_fields_for_partial_update(update_data)
                 if update_many:
                     result = await svc.update_many_existing_fields(
-                        coll_name, filt, plain
+                        coll_name, filt, schema_sample
                     )
                 else:
                     result = await svc.update_one_existing_fields(
-                        coll_name, filt, plain
+                        coll_name, filt, schema_sample
                     )
 
             if schema_sample:

--- a/backend/api/infrastructure/query_safety.py
+++ b/backend/api/infrastructure/query_safety.py
@@ -27,6 +27,7 @@ ALLOWED_UPDATE_OPERATORS = frozenset(
 FORBIDDEN_UPDATE_KEYS = frozenset({"$out", "$merge", "$replaceRoot", "$replaceWith"})
 
 MAX_INSERT_BATCH = 500
+MAX_BULK_UPDATE_OPERATIONS = 500
 
 
 def _walk_filter(node: Any, *, path: str = "") -> None:

--- a/backend/api/infrastructure/signing.py
+++ b/backend/api/infrastructure/signing.py
@@ -13,11 +13,14 @@ def generate_signed_url(
 ) -> str:
     """
     Generate a signed URL for a file that expires after a given time.
-    :param file_id: The GridFS file ID (as string)
-    :param user_id: The user's ID (must match the owner)
-    :param expires_in_seconds: URL validity duration (default 5 minutes)
-    :param path_prefix: API endpoint path (adjust as needed)
-    :return: Full signed URL (relative path, without domain)
+    
+    Args:
+        file_id: The GridFS file ID (as string)
+        user_id: The user's ID (must match the owner)
+        expires_in_seconds: URL validity duration (default 5 minutes)
+        path_prefix: API endpoint path (adjust as needed)
+    
+    Returns: Full signed URL (relative path, without domain)
     """
     expire_at = int(time.time()) + expires_in_seconds
     message = f"{file_id}:{user_id}:{expire_at}"

--- a/backend/api/presentation/serializers.py
+++ b/backend/api/presentation/serializers.py
@@ -7,6 +7,7 @@ This module contains all serializers used by the API, organized by functionality
 import re
 from rest_framework import serializers
 from api.domain.metadata_models import FIELD_TYPE_CHOICES, normalize_field_type
+from api.infrastructure.query_safety import MAX_BULK_UPDATE_OPERATIONS
 from api.infrastructure.validators import validate_collection_name, validate_unique_fields
 
 
@@ -214,6 +215,68 @@ class UpdateDocumentSerializer(DocumentBaseSerializer):
                 }
             )
         return attrs
+
+
+class BulkUpdateOperationSerializer(serializers.Serializer):
+    """One updateOne operation inside a bulk CRUD request."""
+
+    filters = serializers.JSONField(
+        help_text="MongoDB query; must be non-empty and include _id or id."
+    )
+    update_data = serializers.JSONField(
+        help_text="Plain field map or allowed update operators ($set, $inc, …)."
+    )
+    update_all_fields = serializers.BooleanField(
+        default=False,
+        help_text=(
+            "If true, apply update_data with $set/operators (may add new fields). "
+            "Required when upsert is true."
+        ),
+    )
+    upsert = serializers.BooleanField(
+        default=False,
+        help_text="If true, insert when no active document matches (requires _id/id).",
+    )
+
+    def validate_filters(self, value):
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("Filters must be a valid JSON object/dictionary.")
+        if not value:
+            raise serializers.ValidationError("filters must not be empty.")
+        return value
+
+    def validate_update_data(self, value):
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("Update data must be a valid JSON object/dictionary.")
+        if not value:
+            raise serializers.ValidationError("update_data must not be empty.")
+        return value
+
+    def validate(self, attrs):
+        filters = attrs.get("filters") or {}
+        upsert = attrs.get("upsert", False)
+        update_all_fields = attrs.get("update_all_fields", False)
+
+        if "_id" not in filters and "id" not in filters:
+            raise serializers.ValidationError(
+                {"filters": "Each operation requires _id or id in filters."}
+            )
+        if upsert and not update_all_fields:
+            raise serializers.ValidationError(
+                {"upsert": "Requires update_all_fields=true."}
+            )
+        return attrs
+
+
+class BulkUpdateDocumentSerializer(DocumentBaseSerializer):
+    """Validates a batch of per-document update/upsert operations."""
+
+    operations = BulkUpdateOperationSerializer(
+        many=True,
+        min_length=1,
+        max_length=MAX_BULK_UPDATE_OPERATIONS,
+        help_text="One to 500 independent updateOne operations (optional upsert per row).",
+    )
 
 
 class DeleteDocumentSerializer(DocumentBaseSerializer):

--- a/backend/api/presentation/urls_v2.py
+++ b/backend/api/presentation/urls_v2.py
@@ -16,7 +16,7 @@ from api.presentation.views.database_views import (
     CreateDatabaseView,
     AddCollectionView,
 )
-from api.presentation.views.crud_views import DataCrudView
+from api.presentation.views.crud_views import DataCrudView, DataCrudBulkView
 
 from api.presentation.views.file_views import (
     FileListView,
@@ -42,6 +42,7 @@ urlpatterns = [
 
     # CRUD operations - Handles POST, PUT, DELETE, so re_path is critical
     re_path(r"^crud/?$", DataCrudView.as_view(), name="crud"),
+    re_path(r"^crud/bulk/?$", DataCrudBulkView.as_view(), name="crud_bulk"),
 
     # File operations
      # List and upload files

--- a/backend/api/presentation/views/crud_views.py
+++ b/backend/api/presentation/views/crud_views.py
@@ -15,6 +15,7 @@ from api.presentation.views.base import BaseAPIView
 from api.presentation.serializers import (
     AsyncPostDocumentSerializer,
     UpdateDocumentSerializer,
+    BulkUpdateDocumentSerializer,
     DeleteDocumentSerializer,
     DocumentQuerySerializer,
 )
@@ -267,3 +268,49 @@ class DataCrudView(BaseAPIView):
             "success": True, 
             "count": affected_count
         }, status=status.HTTP_200_OK)
+
+
+class DataCrudBulkView(DataCrudView):
+    """Batch per-document update/upsert via MongoDB bulkWrite."""
+
+    @BaseAPIView.handle_errors
+    async def post(self, request):
+        op_start = time.perf_counter()
+        payload = self.validate_serializer(BulkUpdateDocumentSerializer, request.data)
+
+        db_id = payload["database_id"]
+        coll_name = payload["collection_name"]
+        operations = []
+        for op in payload["operations"]:
+            raw_filters = safe_load_filters(op.get("filters", {}))
+            operations.append(
+                {
+                    "filters": normalize_id_filter(raw_filters),
+                    "update_data": op["update_data"],
+                    "update_all_fields": op.get("update_all_fields", False),
+                    "upsert": op.get("upsert", False),
+                }
+            )
+
+        result = await self.doc_svc.bulk_update_docs(
+            db_id=db_id,
+            coll_name=coll_name,
+            operations=operations,
+        )
+
+        has_errors = bool(result.get("errors"))
+        self._capture_mongo_analytics(
+            request,
+            db_id,
+            coll_name,
+            operation_type="bulk_update",
+            document_count=len(operations),
+            result=None,
+            start_time=op_start,
+        )
+
+        body = {
+            "success": not has_errors,
+            **result,
+        }
+        return Response(body, status=status.HTTP_200_OK)

--- a/backend/api/tests/test_bulk_update.py
+++ b/backend/api/tests/test_bulk_update.py
@@ -1,0 +1,101 @@
+import pytest
+from bson import ObjectId
+from unittest.mock import AsyncMock, MagicMock
+
+from api.application.document_service import DocumentService
+from api.presentation.serializers import BulkUpdateDocumentSerializer
+
+
+def test_bulk_serializer_rejects_upsert_without_update_all_fields():
+    serializer = BulkUpdateDocumentSerializer(
+        data={
+            "database_id": str(ObjectId()),
+            "collection_name": "users",
+            "operations": [
+                {
+                    "filters": {"_id": str(ObjectId())},
+                    "update_data": {"points": 1},
+                    "upsert": True,
+                }
+            ],
+        }
+    )
+    assert serializer.is_valid() is False
+    assert "upsert" in serializer.errors["operations"][0]
+
+
+def test_bulk_serializer_requires_id_per_operation():
+    serializer = BulkUpdateDocumentSerializer(
+        data={
+            "database_id": str(ObjectId()),
+            "collection_name": "users",
+            "operations": [
+                {
+                    "filters": {"status": "active"},
+                    "update_data": {"points": 1},
+                    "update_all_fields": True,
+                }
+            ],
+        }
+    )
+    assert serializer.is_valid() is False
+    assert "filters" in serializer.errors["operations"][0]
+
+
+@pytest.mark.django_db
+def test_crud_bulk_endpoint(authenticated_api_client, mocker):
+    database_id = str(ObjectId())
+    mock_response = {
+        "matched_count": 1,
+        "modified_count": 1,
+        "upserted_count": 1,
+        "results": [
+            {"index": 0, "ok": True},
+            {"index": 1, "ok": True, "upserted_id": str(ObjectId())},
+        ],
+    }
+    mocker.patch(
+        "api.application.document_service.DocumentService.bulk_update_docs",
+        new=AsyncMock(return_value=mock_response),
+    )
+
+    url = "/api/v2/crud/bulk/"
+    data = {
+        "database_id": database_id,
+        "collection_name": "users",
+        "operations": [
+            {
+                "filters": {"_id": str(ObjectId())},
+                "update_data": {"points": 120},
+                "update_all_fields": True,
+                "upsert": True,
+            },
+            {
+                "filters": {"_id": str(ObjectId())},
+                "update_data": {"points": 450},
+                "update_all_fields": True,
+                "upsert": True,
+            },
+        ],
+    }
+    response = authenticated_api_client.post(url, data=data, format="json")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is True
+    assert body["upserted_count"] == 1
+    assert len(body["results"]) == 2
+
+
+def test_format_bulk_write_response_marks_failed_indices():
+    body = DocumentService._format_bulk_write_response(
+        op_count=2,
+        matched_count=1,
+        modified_count=1,
+        upserted_count=0,
+        upserted_by_index={},
+        write_errors=[{"index": 1, "errmsg": "duplicate key"}],
+    )
+    assert body["results"][0]["ok"] is True
+    assert body["results"][1]["ok"] is False
+    assert body["results"][1]["error"] == "duplicate key"
+    assert len(body["errors"]) == 1

--- a/backend/api/tests/test_bulk_update.py
+++ b/backend/api/tests/test_bulk_update.py
@@ -1,6 +1,6 @@
 import pytest
 from bson import ObjectId
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 from api.application.document_service import DocumentService
 from api.presentation.serializers import BulkUpdateDocumentSerializer

--- a/backend/docs/FRONTEND_API_GUIDE.md
+++ b/backend/docs/FRONTEND_API_GUIDE.md
@@ -425,8 +425,10 @@ Soft-deleted documents (`is_deleted: true`) are excluded from results.
 |-------|---------|---------|
 | `update_data` | — | Plain field map **or** allowed operators (`$set`, `$inc`, `$unset`, …) |
 | `update_all_fields` | `false` | `true`: full `$set`/operators (may add fields). `false`: only change fields that already exist on each doc |
-| `update_many` | `false` | `true`: update every match; `false`: single-document (requires `_id`/`id` in filters) |
+| `update_many` | `false` | `true`: apply the **same** update to **all** matches for **one** filter; `false`: single-document (requires `_id`/`id` in filters) |
 | `upsert` | `false` | With `_id`/`id` filter, create document if none matches (`update_many` must be `false`) |
+
+**`upsert` + `update_many`:** not supported. MongoDB `updateMany` + `upsert` inserts at most one document when zero rows match — it cannot update some rows and insert others from a list. Use **bulk update** (below) for that pattern.
 
 **Examples**
 
@@ -463,6 +465,55 @@ Soft-deleted documents (`is_deleted: true`) are excluded from results.
 
 **200** — `{ "success": true, "modified_count": n, "matched_count": m, "upserted_id": "..." }`  
 `upserted_id` is present only when a new document was inserted.
+
+#### Bulk update / upsert — `POST /api/v2/crud/bulk/`
+
+Use when you have **multiple documents** and each may need its own update or upsert (e.g. sync loyalty points for many users). One network round-trip via MongoDB `bulkWrite`.
+
+```json
+{
+  "database_id": "<24_hex_objectid>",
+  "collection_name": "users",
+  "operations": [
+    {
+      "filters": { "_id": "674a1b2c3d4e5f6789012345" },
+      "update_data": { "points": 120 },
+      "update_all_fields": true,
+      "upsert": true
+    },
+    {
+      "filters": { "_id": "674a1b2c3d4e5f6789012346" },
+      "update_data": { "points": 450 },
+      "update_all_fields": true,
+      "upsert": true
+    }
+  ]
+}
+```
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `operations` | — | **1–500** items; each runs as `updateOne` |
+| `filters` | — | Required; must include `_id` or `id` |
+| `update_all_fields` | `false` | Same as PUT; **`upsert` requires `true`** |
+| `upsert` | `false` | Insert when no active document matches |
+
+**200** example:
+
+```json
+{
+  "success": true,
+  "matched_count": 1,
+  "modified_count": 1,
+  "upserted_count": 1,
+  "results": [
+    { "index": 0, "ok": true },
+    { "index": 1, "ok": true, "upserted_id": "674a1b2c3d4e5f6789012347" }
+  ]
+}
+```
+
+If some operations fail (`ordered: false`), successful ops still apply; failed indices appear in `errors`.
 
 #### Delete — `DELETE`
 

--- a/datacube_documentation.md
+++ b/datacube_documentation.md
@@ -322,14 +322,53 @@ Max **500** documents per request. Use `documents`, not `data`.
 | Field | Default | Meaning |
 |-------|---------|---------|
 | `update_all_fields` | false | true: may add fields; false: patch existing fields only |
-| `update_many` | false | true: update all matches; false: single doc (`_id` in filters) |
-| `upsert` | false | Create if missing (requires `_id`/`id`, `update_many` false) |
+| `update_many` | false | true: apply the **same** update to **all** docs matching **one** filter; false: single doc (`_id` in filters) |
+| `upsert` | false | Create if missing (requires `_id`/`id`, `update_many` false). **Cannot** be combined with `update_many`. |
 
 `update_data` may use operators: `$set`, `$inc`, `$unset`, etc.
 
 **200** — `{ "success", "modified_count", "matched_count", "upserted_id?" }`
 
+**Note:** `upsert` + `update_many` does not support “update some docs and insert others” in one call. MongoDB `updateMany` with `upsert: true` inserts at most **one** document when zero matches are found. For mixed per-document update/insert batches, use **Bulk update** below.
+
 **Safety:** non-empty `filters`; dangerous operators rejected; unknown DB/collection → **403**.
+
+#### Bulk update / upsert — `POST /api/v2/crud/bulk/`
+
+Sync many documents in one request: each operation runs as an independent `updateOne` (update if found, optional insert if missing). Backed by MongoDB `bulkWrite`.
+
+```json
+{
+  "database_id": "<24_hex>",
+  "collection_name": "users",
+  "operations": [
+    {
+      "filters": { "_id": "<24_hex>" },
+      "update_data": { "points": 120 },
+      "update_all_fields": true,
+      "upsert": true
+    },
+    {
+      "filters": { "_id": "<24_hex>" },
+      "update_data": { "points": 450 },
+      "update_all_fields": true,
+      "upsert": true
+    }
+  ]
+}
+```
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `operations` | — | 1–500 items; each item is one `updateOne` |
+| `filters` | — | Required per op; must include `_id` or `id` |
+| `update_data` | — | Same rules as single PUT |
+| `update_all_fields` | false | Same as single PUT; **`upsert` requires `true`** |
+| `upsert` | false | Insert when no active (non-deleted) doc matches |
+
+**200** — `{ "success", "matched_count", "modified_count", "upserted_count", "results": [{ "index", "ok", "upserted_id?" }], "errors?" }`
+
+Per-operation `matched_count` / `modified_count` are not returned; use aggregate totals and `upserted_id` per index when a row was inserted.
 
 #### Delete — DELETE
 

--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -27,6 +27,13 @@ server {
     ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
     ssl_ecdh_curve secp384r1;
 
+    # Demo playground (static HTML)
+    location /demo/ {
+        alias /usr/share/nginx/html/demo/;
+        index demo-playground.html;
+        try_files $uri $uri/ /demo/demo-playground.html;
+    }
+
     # 1. Frontend (Multi-stage Nginx uses port 80)
     location / {
         # 'react-app' matches the service name in docker-compose
@@ -83,10 +90,4 @@ server {
         add_header Cache-Control "public, no-transform";
     }
 
-    # Demo playground (static HTML)
-    location /demo/ {
-        alias /usr/share/nginx/html/demo/;
-        index demo-playground.html;
-        try_files $uri $uri/ /demo/demo-playground.html;
-    }
 }


### PR DESCRIPTION
**PR description**

## Summary

- Adds **`POST /api/v2/crud/bulk/`** for syncing many documents in one request — each operation runs as an independent `updateOne` with optional `upsert`, backed by MongoDB `bulkWrite` (max **500** ops).
- Clarifies in docs that **`upsert` cannot be combined with `update_many`** on `PUT /api/v2/crud/` — MongoDB only inserts at most one document when zero rows match a single filter, so mixed “update some / insert others” needs the bulk endpoint.
- Documents the new endpoint in `datacube_documentation.md`, `FRONTEND_API_GUIDE.md`, `README.md`, and the in-app API reference.

## Problem

Users syncing a batch of records (some existing, some new) cannot do that with `update_many` + `upsert`. The API already blocked that combo; this adds the correct pattern.

## Solution

```json
POST /api/v2/crud/bulk/
{
  "database_id": "<db_id>",
  "collection_name": "users",
  "operations": [
    {
      "filters": { "_id": "aaa..." },
      "update_data": { "points": 120 },
      "update_all_fields": true,
      "upsert": true
    },
    {
      "filters": { "_id": "bbb..." },
      "update_data": { "points": 450 },
      "update_all_fields": true,
      "upsert": true
    }
  ]
}
```

**Response:** `matched_count`, `modified_count`, `upserted_count`, and per-op `results` (with `upserted_id` when a row was inserted).

## Rules (same as single PUT)

- Each operation requires `_id` or `id` in `filters`
- `upsert` requires `update_all_fields: true`
- Reuses existing update validation, RBAC, and schema inference

## Also in this branch

- Minor: `generate_signed_url` docstring cleanup
- Minor: move `/demo/` nginx location earlier in `nginx.prod.conf`

## Test plan

- [x] `uv run pytest api/tests/test_bulk_update.py -q`
- [x] `PUT /api/v2/crud/` with `upsert: true` + `update_many: true` → **400** (unchanged)
- [x] `POST /api/v2/crud/bulk/` with 2 ops (one existing `_id`, one new `_id`) → one updated, one inserted
- [x] `POST /api/v2/crud/bulk/` with `upsert: true` but `update_all_fields: false` → **400**
- [x] Verify docs / `/api-docs` show the new bulk endpoint and `upsert` + `update_many` limitation